### PR TITLE
Add derives for the main structs

### DIFF
--- a/src/element.rs
+++ b/src/element.rs
@@ -1,5 +1,6 @@
 use crate::{UncertainFloat, Isotope, XrayScatteringFactor, AtomicScatteringFactor, NeutronScatteringFactor};
 
+#[derive(Debug, Clone)]
 pub struct Element {
     pub atomic_number: u8,
     pub name: &'static str,

--- a/src/isotope.rs
+++ b/src/isotope.rs
@@ -1,5 +1,6 @@
 use crate::{UncertainFloat, XrayScatteringFactor, NeutronScatteringFactor};
 
+#[derive(Debug, Clone)]
 pub struct Isotope {
     pub mass_number: u16,
     pub mass: UncertainFloat,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,11 +8,11 @@ pub mod neutron_sf;
 pub mod table;
 pub mod utils;
 
-use element::Element;
-use isotope::Isotope;
-use utils::UncertainFloat;
-use xray_sf::{AtomicScatteringFactor, XrayScatteringFactor};
-use neutron_sf::NeutronScatteringFactor;
+pub use element::Element;
+pub use isotope::Isotope;
+pub use utils::UncertainFloat;
+pub use xray_sf::{AtomicScatteringFactor, XrayScatteringFactor};
+pub use neutron_sf::NeutronScatteringFactor;
 
 // use element_basic_info::ElementBasicInfo;
 // use element_neutron_scattering::ElementNeutronScattering;

--- a/src/neutron_sf.rs
+++ b/src/neutron_sf.rs
@@ -1,5 +1,6 @@
 use crate::UncertainFloat;
 
+#[derive(Debug, Clone, Copy)]
 pub struct NeutronScatteringFactor {
     pub b_c: UncertainFloat, //bound coherent scattering length (in fm)
     pub b_p: Option<UncertainFloat>, 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,6 +1,6 @@
 use std::fmt::Display;
 
-#[derive(Clone)]
+#[derive(Debug, Copy, Clone)]
 pub struct UncertainFloat {
     pub value: f64,
     pub uncertainty: f64

--- a/src/xray_sf.rs
+++ b/src/xray_sf.rs
@@ -1,9 +1,11 @@
+#[derive(Debug, Copy, Clone)]
 pub struct AtomicScatteringFactor {
     pub energy: f64,
     pub f1: Option<f64>,
     pub f2: Option<f64>
 }
 
+#[derive(Debug, Clone)]
 pub struct XrayScatteringFactor {
     pub table: Vec<AtomicScatteringFactor> // E, f1, f2
 }


### PR DESCRIPTION
Hello! Cooking up another nice crate I see! 
These changes make using the main structs easier for other crates. 

I was playing around making a higher-level interface based on this one:, something like: 

 ```rust
use periodictable::elements::*;

let hydrogen: Element = H::load();
let oxygen: Element = O::load();

let h2o = Compound::new()
                    .add_element(&hydrogen)
                    .add_element(&hydrogen)
                    .add_element(&oxygen);

assert_eq!(h2o.mass(), 18.01528);
```

and was having trouble moving elements around. 